### PR TITLE
Use dependencies from staging repository

### DIFF
--- a/conversion-api/pom.xml
+++ b/conversion-api/pom.xml
@@ -31,7 +31,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.xtable</groupId>
-            <artifactId>xtable-hudi-support-extensions</artifactId>
+            <artifactId>incubator-xtable-core</artifactId>
             <version>${xtable.version}</version>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,14 @@
         <module>common</module>
     </modules>
 
+    <repositories>
+        <repository>
+            <id>apache-staging</id>
+            <name>Apache Staging Repository for XTable</name>
+            <url>https://repository.apache.org/content/repositories/orgapachextable-1000/</url>
+        </repository>
+    </repositories>
+
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
@@ -23,7 +31,7 @@
         <delta.version>2.4.0</delta.version>
         <hudi.version>0.14.0</hudi.version>
         <iceberg.version>1.4.2</iceberg.version>
-        <xtable.version>0.1.0-SNAPSHOT</xtable.version>
+        <xtable.version>0.1.0-rc1</xtable.version>
         <jackson.version>2.17.1</jackson.version>
         <scala.version>2.12.15</scala.version>
         <scala.version.prefix>2.12</scala.version.prefix>


### PR DESCRIPTION
```
Downloading from apache-staging: https://repository.apache.org/content/repositories/orgapachextable-1000/org/apache/xtable/xtable-hudi-support-extensions/0.1.0-rc1/xtable-hudi-support-extensions-0.1.0-rc1.pom
Downloaded from apache-staging: https://repository.apache.org/content/repositories/orgapachextable-1000/org/apache/xtable/xtable-hudi-support-extensions/0.1.0-rc1/xtable-hudi-support-extensions-0.1.0-rc1.pom (6.2 kB at 10 kB/s)
Downloading from apache-staging: https://repository.apache.org/content/repositories/orgapachextable-1000/org/apache/xtable/incubator-xtable-core/0.1.0-rc1/incubator-xtable-core-0.1.0-rc1.pom
Downloaded from apache-staging: https://repository.apache.org/content/repositories/orgapachextable-1000/org/apache/xtable/incubator-xtable-core/0.1.0-rc1/incubator-xtable-core-0.1.0-rc1.pom (6.1 kB at 36 kB/s)
Downloading from apache-staging: https://repository.apache.org/content/repositories/orgapachextable-1000/org/apache/xtable/xtable-hudi-support-extensions/0.1.0-rc1/xtable-hudi-support-extensions-0.1.0-rc1-bundled.jar
Progress (1): 51/132 MB  
```

Ensure rc-1 dependencies are downloaded.